### PR TITLE
Bugfix/pandas sort frames

### DIFF
--- a/ipfn/ipfn.py
+++ b/ipfn/ipfn.py
@@ -186,7 +186,6 @@ class ipfn(object):
         tables = [df]
         for inc in range(steps - 1):
             tables.append(df.copy())
-        original = df.copy()
 
         # Calculate the new weights for each dimension
         inc = 0
@@ -235,7 +234,6 @@ class ipfn(object):
             table_update.reset_index(inplace=True)
             table_current.reset_index(inplace=True)
             inc += 1
-            feat_l = []
 
         # Calculate the max convergence rate
         max_conv = 0

--- a/ipfn/ipfn.py
+++ b/ipfn/ipfn.py
@@ -182,20 +182,13 @@ class ipfn(object):
         print(df)
         print(df.groupby('age')['total'].sum(), xip)"""
 
-        steps = len(aggregates)
-        tables = [df]
-        for inc in range(steps - 1):
-            tables.append(df.copy())
-
         # Calculate the new weights for each dimension
         inc = 0
+
+        table_current = df.copy()
+
         for features in dimensions:
-            if inc == (steps - 1):
-                table_update = df
-                table_current = tables[inc].copy()
-            else:
-                table_update = tables[inc + 1]
-                table_current = tables[inc]
+            table_update = table_current.copy()
 
             tmp = table_current.groupby(features)[weight_col].sum()
             xijk = aggregates[inc]
@@ -233,6 +226,9 @@ class ipfn(object):
 
             table_update.reset_index(inplace=True)
             table_current.reset_index(inplace=True)
+
+            table_current = table_update
+
             inc += 1
 
         # Calculate the max convergence rate


### PR DESCRIPTION
This is one of the possible resolutions for issue #28

The minimal example provided there does not cause the code itself to break, it was merely to illustrate what causes the issue deeper down, so a more involved (probably not minimal) example is provided as a new test.

There are other possible solutions to the issue, such as resetting the sort order when the `reset_index` is called, but this is quite a minimal change that does not appear to affect the inner working.